### PR TITLE
Fix deprecation message caused by the use of SwitchDevice

### DIFF
--- a/custom_components/brematic/switch.py
+++ b/custom_components/brematic/switch.py
@@ -6,7 +6,7 @@ import voluptuous as vol
 from homeassistant.components.switch import (
     ENTITY_ID_FORMAT,
     PLATFORM_SCHEMA,
-    SwitchDevice,
+    SwitchEntity,
 )
 from homeassistant.const import CONF_FRIENDLY_NAME, CONF_HOST, CONF_SWITCHES, STATE_ON
 import homeassistant.helpers.config_validation as cv
@@ -133,7 +133,7 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
     add_entities(switches)
 
 
-class BrematicSwitch(SwitchDevice, RestoreEntity):
+class BrematicSwitch(SwitchEntity, RestoreEntity):
     """Representation a switch that can be toggled using Brematic Gateway"""
 
     def __init__(self, hass, object_id, gateway, unit, friendly_name):


### PR DESCRIPTION
SwitchDevice was renamed to SwitchEntity
See https://developers.home-assistant.io/blog/2020/05/14/entity-class-names/ for details

This fixes the deprecation message in log.