### PR TITLE
feat(#9): added value_template for state assumption

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,10 @@ switch:
       floor_lamp:
         unit_code: '11111'
         unit_type: 'RCS1000N'
+      smartphone_charger:
+        unit_code: '010101'
+        friendly_name: 'Smartphone Camera'
+        value_template: '{{ is_state("binary_sensor.huawei_is_charging", "on") }}'
 ```
 **Please note:** only `switch` is supported. If you want to control your power outlet as a `light` please refer to the [light switch](https://www.home-assistant.io/components/light.switch/) component.
 
@@ -71,6 +75,7 @@ switch:
     - **unit_code**<br />&nbsp;&nbsp;*(string) (Required)* Unit code of the device
     - **unit_type**<br />&nbsp;&nbsp;*(string) (Optional)* Type of the unit (`RCS1000N`, `RCR1000N`, `AB440SA`, `CMR300`, `CMR500`, `CMR1000`, `ITR300`, `ITR3500`, `PAR1500`) <br />&nbsp;&nbsp; default: `RCS1000N`
     - **friendly_name**<br />&nbsp;&nbsp;*(string) (Optional)* Friendly name of the device
+    - **value_template**<br />&nbsp;&nbsp;*(string) (Optional)* [Template](https://www.home-assistant.io/docs/configuration/templating/) for assuming switch state
 
 # Authors & contributors
 The original setup of this repository is by [Tobias Efinger](https://github.com/tefinger).

--- a/custom_components/brematic/const.py
+++ b/custom_components/brematic/const.py
@@ -1,6 +1,6 @@
 """Brematic integration for Home Assistant"""
 
-VERSION = "0.2.1"
+VERSION = "0.5.0"
 
 CONF_SYSTEM_CODE = "system_code"
 CONF_GATEWAY_TYPE = "gateway_type"

--- a/custom_components/brematic/manifest.json
+++ b/custom_components/brematic/manifest.json
@@ -9,5 +9,5 @@
   "requirements": [
     "pyBrematic==1.2.1"
   ],
-  "version": "0.4.0"
+  "version": "0.5.0"
 }


### PR DESCRIPTION
Just had some time and tried to implement the feature from my feature request #9 myself.
I based this on the code from the template switch itself https://github.com/home-assistant/core/blob/39998f538738e341c39461cc5a7f84d916164f6d/homeassistant/components/template/switch.py

I tested it with the use case I described and can confirm that it works with the template as well as without it so no original functionality is broken.