### PR TITLE
Fix "Error while setting up brematic platform for switch"

### DIFF
--- a/custom_components/brematic/switch.py
+++ b/custom_components/brematic/switch.py
@@ -165,12 +165,13 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
     add_entities(switches)
 
 
-class BrematicSwitch(TemplateEntity, SwitchEntity, RestoreEntity):
+class BrematicSwitch(SwitchEntity, RestoreEntity):
     """Representation a switch that can be toggled using Brematic Gateway"""
 
     def __init__(self, hass, object_id, gateway, unit, friendly_name, state_template):
         """Initialize the switch."""
-        super().__init__(hass)
+        super().__init__()
+        self.hass = hass
         self.entity_id = async_generate_entity_id(
             ENTITY_ID_FORMAT, object_id, hass=hass
         )


### PR DESCRIPTION
Since the update to 2025.8.x beta I had this issue in my logs and the integration was not working anymore:
```
2025-08-02 17:57:59.983 ERROR (MainThread) [homeassistant.components.switch] Error while setting up brematic platform for switch: TemplateEntity.__init__() missing 2 required positional arguments: 'config' and 'unique_id'
Traceback (most recent call last):
  File "/usr/src/homeassistant/homeassistant/helpers/entity_platform.py", line 451, in _async_setup_platform
    await asyncio.shield(awaitable)
  File "/usr/local/lib/python3.13/concurrent/futures/thread.py", line 59, in run
    result = self.fn(*self.args, **self.kwargs)
  File "/config/custom_components/brematic/switch.py", line 151, in setup_platform
    BrematicSwitch(
    ~~~~~~~~~~~~~~^
        hass,
        ^^^^^
    ...<4 lines>...
        state_template,
        ^^^^^^^^^^^^^^^
    )
    ^
  File "/config/custom_components/brematic/switch.py", line 173, in __init__
    super().__init__(hass)
    ~~~~~~~~~~~~~~~~^^^^^^
TypeError: TemplateEntity.__init__() missing 2 required positional arguments: 'config' and 'unique_id'
```

This PR should fix this issue (at least it fixed it for me)