### PR TITLE
Fix TemplateEntity.__init__ signature for HA 2025.8.x

### DIFF
--- a/custom_components/brematic/switch.py
+++ b/custom_components/brematic/switch.py
@@ -170,7 +170,7 @@ class BrematicSwitch(TemplateEntity, SwitchEntity, RestoreEntity):
 
     def __init__(self, hass, object_id, gateway, unit, friendly_name, state_template):
         """Initialize the switch."""
-        super().__init__(hass)
+        TemplateEntity.__init__(self, hass, {}, None)
         self.entity_id = async_generate_entity_id(
             ENTITY_ID_FORMAT, object_id, hass=hass
         )


### PR DESCRIPTION
## Summary

- Fixes crash introduced in HA 2025.8.x where `TemplateEntity.__init__()` now requires `config` and `unique_id` positional arguments
- Passes an empty config dict (`{}`) and `None` as `unique_id` — all config keys are accessed via `.get()` internally, so an empty dict is safe
- Keeps `TemplateEntity` in the class hierarchy, preserving full `value_template` support (unlike #17 which would break template-based switches)

## Compared to PR #17

PR #17 removes `TemplateEntity` from the MRO, which fixes the crash for non-template users but leaves `add_template_attribute` and `super()._update_state()` calls that would raise `AttributeError` for any switch configured with `value_template`.

This fix is a single-line change that solves the root cause without sacrificing template support.

Closes #17